### PR TITLE
feat(ghcr) create a ghcr image.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,83 @@
+# This workflow uses actions that are not certified by GitHub.
+
+# They are provided by a third-party and are governed by
+
+# separate terms of service, privacy policy, and support
+
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+
+# To get a newer version, you will need to update the SHA.
+
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Create and publish a Docker image
+
+on:
+
+  push:
+
+    tags:
+
+      - "v*.*.*"
+
+env:
+
+  REGISTRY: ghcr.io
+
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+
+  build-and-push-image:
+
+    runs-on: ubuntu-latest
+
+    permissions:
+
+      contents: read
+
+      packages: write
+
+    steps:
+
+      - name: Checkout repository
+
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+
+        with:
+
+          registry: ${{ env.REGISTRY }}
+
+          username: ${{ github.actor }}
+
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+
+        id: meta
+
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+
+        with:
+
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+
+        with:
+
+          context: .
+
+          push: true
+
+          tags: ${{ steps.meta.outputs.tags }}
+
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This workflow will auto gen a docker image on github(ghcr) when ever a tag version is released like so `v0.0.1`. 